### PR TITLE
add single letter shortcuts to args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ go.work.sum
 # env file
 .env
 .idea
+.vscode

--- a/cmd/gcp-jit/list.go
+++ b/cmd/gcp-jit/list.go
@@ -29,7 +29,7 @@ var listEntitlementCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(listEntitlementCmd)
 
-	listEntitlementCmd.Flags().String("project", "", "Project ID")
-	listEntitlementCmd.Flags().String("location", "global", "Location")
+	listEntitlementCmd.Flags().StringP("project", "p", "", "Project ID")
+	listEntitlementCmd.Flags().StringP("location", "l", "global", "Location")
 	_ = listEntitlementCmd.MarkFlagRequired("project")
 }

--- a/cmd/gcp-jit/request.go
+++ b/cmd/gcp-jit/request.go
@@ -33,9 +33,9 @@ var requestCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(requestCmd)
 
-	requestCmd.Flags().String("project", "", "Project ID")
-	requestCmd.Flags().String("location", "global", "Location")
-	requestCmd.Flags().String("justification", "", "Justification")
+	requestCmd.Flags().StringP("project", "p", "", "Project ID")
+	requestCmd.Flags().StringP("location", "l", "global", "Location")
+	requestCmd.Flags().StringP("justification", "j", "", "Justification")
 
 	requestCmd.MarkFlagRequired("project")
 	requestCmd.MarkFlagRequired("justification")


### PR DESCRIPTION
add shortcuts to the arguments as I'm lazy

```
Flags:
  -h, --help                   help for request
  -j, --justification string   Justification
  -l, --location string        Location (default "global")
  -p, --project string         Project ID
```