### PR TITLE
Add an option to specify a duration for a pam request

### DIFF
--- a/cmd/gcp-jit/request.go
+++ b/cmd/gcp-jit/request.go
@@ -18,12 +18,13 @@ var requestCmd = &cobra.Command{
 		projectID, _ := cmd.Flags().GetString("project")
 		location, _ := cmd.Flags().GetString("location")
 		justification, _ := cmd.Flags().GetString("justification")
+		duration, _ := cmd.Flags().GetString("duration")
 
 		pam, err := pamjit.NewPamJitClient(context.Background(), projectID, location)
 		if err != nil {
 			log.Fatalf("unable to use GCP JIT service: %v", err)
 		}
-		err = pam.RequestGrant(cmd.Context(), entitlementID, justification)
+		err = pam.RequestGrant(cmd.Context(), entitlementID, justification, duration)
 		if err != nil {
 			fmt.Printf("Error requesting entitlement: %v\n", err)
 		}
@@ -36,6 +37,7 @@ func init() {
 	requestCmd.Flags().StringP("project", "p", "", "Project ID")
 	requestCmd.Flags().StringP("location", "l", "global", "Location")
 	requestCmd.Flags().StringP("justification", "j", "", "Justification")
+	requestCmd.Flags().StringP("duration", "d", "", "Duration (defaults to maximum)")
 
 	requestCmd.MarkFlagRequired("project")
 	requestCmd.MarkFlagRequired("justification")

--- a/pkg/pamjit/request.go
+++ b/pkg/pamjit/request.go
@@ -2,11 +2,15 @@ package pamjit
 
 import (
 	"cloud.google.com/go/privilegedaccessmanager/apiv1/privilegedaccessmanagerpb"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
-func (c *Client) RequestGrant(ctx context.Context, entitlementId, justification string) error {
+func (c *Client) RequestGrant(ctx context.Context, entitlementId, justification string, duration string) error {
 	entitlementFqn := fmt.Sprintf("%s/entitlements/%s", c.parent(), entitlementId)
 
 	reqEntitlement := &privilegedaccessmanagerpb.GetEntitlementRequest{
@@ -17,13 +21,26 @@ func (c *Client) RequestGrant(ctx context.Context, entitlementId, justification 
 	if err != nil {
 		return fmt.Errorf("entitlement not found: %v", err)
 	}
-	fmt.Printf("Requesting entitlement %s in project %s for %s\n", entitlementId, c.projectID, entitlement.MaxRequestDuration)
+
+	// convert duration string to google.protobuf.Duration
+	var requestedDuration *durationpb.Duration
+	if duration != "" {
+		var err error
+		requestedDuration, err = parseDurationProto(duration)
+		if err != nil {
+			return fmt.Errorf("invalid duration: %w", err)
+		}
+	} else {
+		requestedDuration = entitlement.MaxRequestDuration
+	}
+
+	fmt.Printf("Requesting entitlement %s in project %s for %s\n", entitlementId, c.projectID, requestedDuration)
 
 	req := &privilegedaccessmanagerpb.CreateGrantRequest{
 		Parent: entitlementFqn,
 		Grant: &privilegedaccessmanagerpb.Grant{
-			Name:              entitlementId,
-			RequestedDuration: entitlement.MaxRequestDuration,
+			Name: entitlementId,
+			RequestedDuration: requestedDuration,
 			Justification: &privilegedaccessmanagerpb.Justification{
 				Justification: &privilegedaccessmanagerpb.Justification_UnstructuredJustification{
 					UnstructuredJustification: justification,
@@ -40,5 +57,43 @@ func (c *Client) RequestGrant(ctx context.Context, entitlementId, justification 
 
 	fmt.Printf("Granted request sent! %s\n", grant.GetState().String())
 
+	// display a link to request to paste in Slack - future could post message directly
+	fmt.Printf("Link to request https://console.cloud.google.com/iam-admin/pam/grants/approvals?project=%s\n", c.projectID)
 	return nil
+}
+
+// parseDurationProto converts a duration string like "30s", "5m", or "2h" to *duration.Duration
+func parseDurationProto(durationStr string) (*durationpb.Duration, error) {
+	durationStr = strings.TrimSpace(durationStr)
+	if durationStr == "" {
+		return nil, fmt.Errorf("duration string is empty")
+	}
+
+	// use a regular expression to extract the numeric value and unit
+	re := regexp.MustCompile(`^(\d+)([smh])$`)
+	matches := re.FindStringSubmatch(durationStr)
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("invalid duration string format: %s", durationStr)
+	}
+
+	// parse the numeric value
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid duration value: %s", matches[1])
+	}
+
+	// calculate the duration in seconds based on the unit
+	var seconds int64
+	switch matches[2] {
+	case "s":
+		seconds = int64(value)
+	case "m":
+		seconds = int64(value) * 60
+	case "h":
+		seconds = int64(value) * 60 * 60
+	default:
+		return nil, fmt.Errorf("invalid duration unit: %s", matches[2])
+	}
+
+	return &durationpb.Duration{Seconds: seconds}, nil
 }


### PR DESCRIPTION
Currently gcp-jit makes a pam request for the default duration that has been defined for an entitlement.

There are times when it's preferable to be able to specify a duration that is less than this time.

This adds a `--duration` (`-d`) option to the `request` type and allows either **s**econds, **m**inutes or **h**ours to be specified (but converts that to seconds as Googles api only allows a seconds value).

Note: There is no handling of a value that is less than the minimum allowed or greater than the maximum defined for that entitlement so relies on the error raised to alert the user.