### PR TITLE
Add support for Slack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It's composed of two main components:
 ## Installation
 
 ```
-go install github.com/felixgborrego/gpc-pam-jit/cmd/gcp-jit
+go install github.com/felixgborrego/gpc-pam-jit/cmd/gcp-jit@latest
 ```
 
 ## Usage:
@@ -52,10 +52,17 @@ gcp-jit request database-access \
      --justification "I need to run a basic query on the prod database"
 ````
 
+* Configure Slack integration:
+```shell
+gcp-jit config slack --token xxxxxxx --channel test1
+```
 
 ## Manual build and run
 
 ```
-go build -o bin/gcp-jit github.com/felixgborrego/gpc-pam-jit/cmd/gcp-jit
+# Run locally for development
+go run .
 
+# Build
+go build -o bin/gcp-jit github.com/felixgborrego/gpc-pam-jit/cmd/gcp-jit
 ```

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/felixgborrego/gpc-pam-jit/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// configCmd defines the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Configure the GCP JIT service",
+}
+
+// slackCmd represents the slack subcommand to configure the Slack integration
+var slackCmd = &cobra.Command{
+	Use:   "slack",
+	Short: "Configure the Slack integration",
+	Run: func(cmd *cobra.Command, args []string) {
+		slackConfig(cmd)
+	},
+}
+
+func slackConfig(cmd *cobra.Command) {
+	channel, _ := cmd.Flags().GetString("channel")
+	token, _ := cmd.Flags().GetString("token")
+
+	// Save the configuration
+	conf := config.Config{
+		Slack: config.SlackConfig{
+			Channel: channel,
+			Token:   token,
+		},
+	}
+
+	if err := config.SaveConfig(&conf); err != nil {
+		fmt.Println("Error saving the configuration:", err)
+		return
+	}
+	fmt.Println("Configuration saved")
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(slackCmd)
+
+	slackCmd.Flags().StringP("channel", "c", "", "Slack channel to send messages to")
+	slackCmd.Flags().StringP("token", "t", "", "Slack token")
+	_ = slackCmd.MarkFlagRequired("channel")
+	_ = slackCmd.MarkFlagRequired("token")
+}

--- a/cmd/gcp-jit/main.go
+++ b/cmd/gcp-jit/main.go
@@ -1,5 +1,0 @@
-package main
-
-func main() {
-	Execute()
-}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,9 +1,10 @@
-package main
+package cmd
 
 import (
 	"context"
-	"github.com/felixgborrego/gpc-pam-jit/pkg/pamjit"
 	"log"
+
+	"github.com/felixgborrego/gpc-pam-jit/pkg/pamjit"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -1,10 +1,11 @@
-package main
+package cmd
 
 import (
 	"context"
 	"fmt"
-	"github.com/felixgborrego/gpc-pam-jit/pkg/pamjit"
 	"log"
+
+	"github.com/felixgborrego/gpc-pam-jit/pkg/pamjit"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"

--- a/go.mod
+++ b/go.mod
@@ -44,4 +44,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240722135656-d784300faade // indirect
 	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/felixgborrego/gpc-pam-jit/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const Version = "v1"
+
+type SlackConfig struct {
+	Token   string `yaml:"token"`   // Slack token
+	Channel string `yaml:"channel"` // Slack channel
+}
+
+type Config struct {
+	Slack SlackConfig `yaml:"slack"`
+}
+
+// ConfigFilePath defines the path where the configuration file will be stored
+// ~/.config/gcp-pam-jit-v1.yaml
+var path = filepath.Join(os.Getenv("HOME"), ".config", fmt.Sprintf("gcp-pam-jit-%s.yaml", Version))
+
+// LoadConfig loads the configuration from the YAML file
+func LoadConfig() (*Config, error) {
+	// Check if the config file exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, fmt.Errorf("config file not found at %s", path)
+	}
+
+	// Read the file contents
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file: %w", err)
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("error parsing YAML: %w", err)
+	}
+
+	return &config, nil
+}
+
+// SaveConfig saves the configuration to the YAML file
+func SaveConfig(config *Config) error {
+
+	configDir := filepath.Dir(path)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("error creating config directory: %w", err)
+	}
+
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("error marshaling YAML: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("error writing config file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/pamjit/request.go
+++ b/pkg/pamjit/request.go
@@ -2,9 +2,9 @@ package pamjit
 
 import (
 	"cloud.google.com/go/privilegedaccessmanager/apiv1/privilegedaccessmanagerpb"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"context"
 	"fmt"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"regexp"
 	"strconv"
 	"strings"
@@ -39,7 +39,7 @@ func (c *Client) RequestGrant(ctx context.Context, entitlementId, justification 
 	req := &privilegedaccessmanagerpb.CreateGrantRequest{
 		Parent: entitlementFqn,
 		Grant: &privilegedaccessmanagerpb.Grant{
-			Name: entitlementId,
+			Name:              entitlementId,
 			RequestedDuration: requestedDuration,
 			Justification: &privilegedaccessmanagerpb.Justification{
 				Justification: &privilegedaccessmanagerpb.Justification_UnstructuredJustification{


### PR DESCRIPTION
This is the initial implementation to allow the CLI to have a basic state (so far it's been a stateless CLI)

usage: `gcp-jit config slack --token xxxxxxx --channel test1`

I also took the liberty to reorganize the cmd and main package to make it more idiomatic.