### PR TITLE
ignore permission denied error on onboard check

### DIFF
--- a/pkg/pamjit/client.go
+++ b/pkg/pamjit/client.go
@@ -1,10 +1,13 @@
 package pamjit
 
 import (
-	privilegedaccessmanager "cloud.google.com/go/privilegedaccessmanager/apiv1"
-	"cloud.google.com/go/privilegedaccessmanager/apiv1/privilegedaccessmanagerpb"
 	"context"
 	"fmt"
+
+	privilegedaccessmanager "cloud.google.com/go/privilegedaccessmanager/apiv1"
+	"cloud.google.com/go/privilegedaccessmanager/apiv1/privilegedaccessmanagerpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Client struct {
@@ -33,6 +36,8 @@ func NewPamJitClient(ctx context.Context, projectID, location string) (*Client, 
 }
 
 // CheckOnboardingStatus checks if the user is onboarded to PAM JIT and returns an error if not.
+// It returns an error only if there's a problem determining the status,
+// but ignores PermissionDenied errors, treating them as not onboarded.
 func (c *Client) CheckOnboardingStatus(ctx context.Context) error {
 	req := &privilegedaccessmanagerpb.CheckOnboardingStatusRequest{
 		Parent: c.parent(),
@@ -40,6 +45,10 @@ func (c *Client) CheckOnboardingStatus(ctx context.Context) error {
 
 	resp, err := c.gcpClient.CheckOnboardingStatus(ctx, req)
 	if err != nil {
+		if status.Code(err) == codes.PermissionDenied {
+			// Treat PermissionDenied as onboarded
+			return nil 
+		}
 		return fmt.Errorf("failed to check onboarding status: %w", err)
 	}
 


### PR DESCRIPTION
To call `CheckOnboardingStatus` requires `privilegedaccessmanager.locations.checkOnboardingStatus` (ref https://cloud.google.com/iam/docs/reference/pam/rest/v1/projects.locations/checkOnboardingStatus) otherwise you get an error like:
```
2024/11/05 11:32:02 unable to use GCP JIT service: onboarding status check failed: failed to check onboarding status: rpc error: code = PermissionDenied desc = Permission 'privilegedaccessmanager.locations.checkOnboardingStatus' denied on resource '//privilegedaccessmanager.googleapis.com/projects/my-project/locations/global' (or it may not exist).
error details: name = ErrorInfo reason = IAM_PERMISSION_DENIED domain = privilegedaccessmanager.googleapis.com metadata = map[permission:privilegedaccessmanager.locations.checkOnboardingStatus resource:projects/my-project/locations/global]
```

It doesn't make sense to add this permission in the base allowed list for an org using PAM so this change chooses to ignore the OnboardingStatus if it gets a 404 PermissionDenied returned and assume that therefore PAM is in use.
